### PR TITLE
Switch from ollama docker container to setup-ollama action

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -38,5 +38,4 @@ jobs:
 
       - name: DEBUG Output updated source file
         run: |
-          cat docs/source/test.rst
-          diff docs/source/test.rst docs/source/test.rst.bak
+          diff docs/source/test.rst docs/source/test.rst.bak || true


### PR DESCRIPTION
Simplify CI by using `ai-actions/setup-ollama` instead of configuring containers manually.