### PR TITLE
Start markdown build in subprocess

### DIFF
--- a/src/sphinx_llm/tests/test_txt.py
+++ b/src/sphinx_llm/tests/test_txt.py
@@ -94,8 +94,7 @@ def test_markdown_generator_setup(sphinx_build):
 
     # Check that the correct event is connected
     events = [call[0] for call in connect_calls]
-    assert "build-finished" in events
-    # No builder-inited event anymore
+    assert "builder-inited" in events
 
 
 def test_build_llms_txt_with_exception(sphinx_build):
@@ -104,7 +103,7 @@ def test_build_llms_txt_with_exception(sphinx_build):
     generator = MarkdownGenerator(app)
 
     # Should not raise
-    generator.build_llms_txt(app, Exception("fail"))
+    generator.combine_builds(app, Exception("fail"))
 
 
 def test_rst_files_have_corresponding_output_files(sphinx_build):


### PR DESCRIPTION
Closes #31 

The markdown builder is now spawned in a background subprocess on the `builder-inited` event of the main build. Then the two builds can run along in parallel.

The merging of the build outputs is then triggered on the `build-finished` event of the primary build. It will wait for the markdown build to complete if it's still running, then merge everything into one output tree.