### PR TITLE
Logging improvements

### DIFF
--- a/src/sphinx_llm/txt.py
+++ b/src/sphinx_llm/txt.py
@@ -65,7 +65,7 @@ class MarkdownGenerator:
 
         if not self.md_build_process:
             logger.warning(
-                "Markdown build process not found, skipping build combination"
+                "Markdown build process not found, skipping build output combination"
             )
             return
 


### PR DESCRIPTION
- Don't log every filename. When this extension is used on projects with thousands of docs files we end up doubling the size of the logs just by listing all the filenames. We already have a log line that says how many 
- If markdown build fails print out the logfile for better debugging.