### PR TITLE
Reuse doctree cache in sequential builds

### DIFF
--- a/src/sphinx_llm/txt.py
+++ b/src/sphinx_llm/txt.py
@@ -122,7 +122,7 @@ class MarkdownGenerator:
             # When building sequentially we can reuse the doctree directory from the primary build
             # but in parallel builds these may clobber each other so we need to use a separate one
             if not self.parallel:
-                sphinx_build_cmd.append("--doctree-dir")
+                sphinx_build_cmd.append("-d")
                 sphinx_build_cmd.append(str(self.app.doctreedir))
 
             logger.info(


### PR DESCRIPTION
If building sequentially the two builds could share a doctree cache directory which would improve build times for the markdown build.