### PR TITLE
Reduce test duplication and complexity

### DIFF
--- a/src/sphinx_llm/tests/test_txt.py
+++ b/src/sphinx_llm/tests/test_txt.py
@@ -4,6 +4,8 @@
 Tests for the sphinx_llm.txt module.
 """
 
+from __future__ import annotations
+
 import re
 import tempfile
 from collections.abc import Generator


### PR DESCRIPTION
## Summary
- Extract shared `_build_sphinx` helper from two near-identical fixtures to eliminate ~25 lines of duplication
- Add `assert_file_exists_with_content` and `get_non_index_rst_files` helpers to reduce boilerplate across tests
- Remove `test_sphinx_build_fixture` (low-value, only validated test infrastructure)
- Remove `test_dirhtml_url_style_markdown_files` (fully covered by suffix mode test)
- Merge `test_dirhtml_both_markdown_formats_by_default` and `test_both_mode_backward_compatibility` into `test_dirhtml_suffix_mode_configuration`
- Simplify `test_invalid_suffix_mode_raises_error` to use the shared helper

Net result: 502 → 275 lines, 10 → 7 test functions, 0 `pytest.skip()` calls, same coverage.

## Test plan
- [x] All 27 tests pass (`uv run pytest src/sphinx_llm/tests/ -v`)
- [x] All pre-commit hooks pass