### PR TITLE
Add custom claude tips and spinner verbs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+    "spinnerVerbs": {
+        "mode": "replace",
+        "verbs": [
+            "Markdownifying",
+            "Sphinxing",
+            "Documentationifying",
+            "LLMifying",
+            "Agentifying"
+        ]
+    },
+    "spinnerTipsOverride": {
+        "excludeDefault": true,
+        "tips": [
+            "You can configure custom tips and spinner verbs in .claude/settings.json"
+        ]
+    }
+}


### PR DESCRIPTION
TIL you can customise Claude's thinking text and tips. You can configure this in project specific settings which is fun! I bet we could put useful things in here to help contributors learn more about the project while they wait for Claude to churn.