### PR TITLE
Resolve Markdown links after output selection

### DIFF
--- a/src/sphinx_llm/markdown_builder.py
+++ b/src/sphinx_llm/markdown_builder.py
@@ -2,22 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 """Markdown builder that preserves Sphinx document targets."""
 
-from typing import Optional
-from urllib.parse import quote
+import json
+from pathlib import Path
+from typing import Optional, TypedDict
+from uuid import uuid4
 
 from docutils import nodes
 from sphinx_markdown_builder.builder import MarkdownBuilder
 from sphinx_markdown_builder.translator import MarkdownTranslator
 
 LINK_TOKEN_PREFIX = "sphinx-llm:"
+LINK_TARGETS_FILENAME = ".sphinx-llm-link-targets.json"
 
 
-def link_token(docname: str, fragment: Optional[str] = None) -> str:
-    """Return a link token for a Sphinx document target."""
-    token = f"{LINK_TOKEN_PREFIX}{quote(docname, safe='/')}"
-    if fragment:
-        token = f"{token}#{quote(fragment, safe='')}"
-    return token
+class LinkTarget(TypedDict):
+    """Sphinx document target stored for an opaque link token."""
+
+    docname: str
+    fragment: Optional[str]
 
 
 class SphinxLlmMarkdownTranslator(MarkdownTranslator):
@@ -32,9 +34,9 @@ class SphinxLlmMarkdownTranslator(MarkdownTranslator):
         if node.get("internal", self.status.default_ref_internal):
             ref_id = node.get("refid")
             if ref_id is not None:
-                return link_token(self.builder.current_doc_name, ref_id)
+                return self.builder.link_token(self.builder.current_doc_name, ref_id)
             if not node.get("refuri", ""):
-                return link_token(self.builder.current_doc_name)
+                return self.builder.link_token(self.builder.current_doc_name)
         return super()._fetch_ref_uri(node)
 
 
@@ -44,8 +46,34 @@ class SphinxLlmMarkdownBuilder(MarkdownBuilder):
     name = "llms-markdown"
     default_translator_class = SphinxLlmMarkdownTranslator
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._link_target_by_token: dict[str, LinkTarget] = {}
+        self._link_token_by_target: dict[tuple[str, Optional[str]], str] = {}
+
+    def link_token(self, docname: str, fragment: Optional[str] = None) -> str:
+        """Return an opaque token for a Sphinx document target."""
+        target = (docname, fragment)
+        token = self._link_token_by_target.get(target)
+        if token is None:
+            token = f"{LINK_TOKEN_PREFIX}{uuid4().hex}"
+            self._link_token_by_target[target] = token
+            self._link_target_by_token[token] = {
+                "docname": docname,
+                "fragment": fragment,
+            }
+        return token
+
     def get_target_uri(self, docname: str, typ: Optional[str] = None) -> str:
-        return link_token(docname)
+        return self.link_token(docname)
 
     def get_relative_uri(self, from_: str, to: str, typ: Optional[str] = None) -> str:
-        return link_token(to)
+        return self.link_token(to)
+
+    def finish(self):
+        super().finish()
+        targets_path = Path(self.outdir) / LINK_TARGETS_FILENAME
+        targets_path.write_text(
+            json.dumps(self._link_target_by_token, sort_keys=True),
+            encoding="utf-8",
+        )

--- a/src/sphinx_llm/markdown_builder.py
+++ b/src/sphinx_llm/markdown_builder.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Markdown builder that preserves Sphinx document targets."""
+
+from typing import Optional
+from urllib.parse import quote
+
+from docutils import nodes
+from sphinx_markdown_builder.builder import MarkdownBuilder
+from sphinx_markdown_builder.translator import MarkdownTranslator
+
+LINK_TOKEN_PREFIX = "sphinx-llm:"
+
+
+def link_token(docname: str, fragment: Optional[str] = None) -> str:
+    """Return a link token for a Sphinx document target."""
+    token = f"{LINK_TOKEN_PREFIX}{quote(docname, safe='/')}"
+    if fragment:
+        token = f"{token}#{quote(fragment, safe='')}"
+    return token
+
+
+class SphinxLlmMarkdownTranslator(MarkdownTranslator):
+    """Preserve document targets until sphinx-llm selects output paths."""
+
+    def _adjust_url(self, url: str) -> str:
+        if url.startswith(LINK_TOKEN_PREFIX):
+            return url
+        return super()._adjust_url(url)
+
+    def _fetch_ref_uri(self, node: nodes.reference) -> str:
+        if node.get("internal", self.status.default_ref_internal):
+            ref_id = node.get("refid")
+            if ref_id is not None:
+                return link_token(self.builder.current_doc_name, ref_id)
+            if not node.get("refuri", ""):
+                return link_token(self.builder.current_doc_name)
+        return super()._fetch_ref_uri(node)
+
+
+class SphinxLlmMarkdownBuilder(MarkdownBuilder):
+    """Write Markdown with links that retain Sphinx document names."""
+
+    name = "llms-markdown"
+    default_translator_class = SphinxLlmMarkdownTranslator
+
+    def get_target_uri(self, docname: str, typ: Optional[str] = None) -> str:
+        return link_token(docname)
+
+    def get_relative_uri(self, from_: str, to: str, typ: Optional[str] = None) -> str:
+        return link_token(to)

--- a/src/sphinx_llm/tests/test_txt.py
+++ b/src/sphinx_llm/tests/test_txt.py
@@ -305,7 +305,11 @@ def test_dirhtml_links_match_published_locations(tmp_path: Path):
         ".. _page-details:\n\n"
         "Details\n"
         "-------\n\n"
-        "See :ref:`Details <page-details>`.\n",
+        "See :ref:`Details <page-details>`.\n\n"
+        "The URI ``sphinx-llm:example`` is literal content.\n\n"
+        ".. code-block:: text\n\n"
+        "   sphinx-llm:example\n\n"
+        "`Custom scheme <sphinx-llm:example>`_\n",
         encoding="utf-8",
     )
     (guide_dir / "target.rst").write_text(
@@ -323,6 +327,7 @@ def test_dirhtml_links_match_published_locations(tmp_path: Path):
         freshenv=True,
     )
     app.build()
+    assert "llms-markdown" not in app.registry.builders
 
     file_suffix_page = (output_dir / "guide/page/index.html.md").read_text(
         encoding="utf-8"
@@ -337,7 +342,11 @@ def test_dirhtml_links_match_published_locations(tmp_path: Path):
     assert "# guide/page/index.html.md" in llms_full
     assert "[Target](guide/target/index.html.md)" in llms_full
     assert "[Details](guide/page/index.html.md#page-details)" in llms_full
-    assert "sphinx-llm:" not in file_suffix_page + url_suffix_page + llms_full
+    for content in (file_suffix_page, url_suffix_page, llms_full):
+        assert "`sphinx-llm:example`" in content
+        assert "[Custom scheme](sphinx-llm:example)" in content
+        assert "sphinx-llm:example\n```" in content
+        assert re.search(r"sphinx-llm:[0-9a-f]{32}", content) is None
 
 
 @pytest.mark.parametrize(

--- a/src/sphinx_llm/tests/test_txt.py
+++ b/src/sphinx_llm/tests/test_txt.py
@@ -259,12 +259,6 @@ def test_dirhtml_suffix_mode_configuration(sphinx_build_with_suffix_mode_config)
         elif effective_mode == "auto":
             assert_file_exists_with_content(file_suffix_md)
             assert_file_exists_with_content(url_suffix_md)
-            # Verify content is the same (they should be copies)
-            assert file_suffix_md.read_text(
-                encoding="utf-8"
-            ) == url_suffix_md.read_text(encoding="utf-8"), (
-                f"Content mismatch between {file_suffix_md} and {url_suffix_md}"
-            )
 
     # Root index should always be generated regardless of suffix mode
     index_file_suffix_md = build_dir / "index.html.md"
@@ -283,6 +277,67 @@ def test_dirhtml_suffix_mode_configuration(sphinx_build_with_suffix_mode_config)
     elif effective_mode == "auto":
         assert_file_exists_with_content(index_file_suffix_md)
         assert_file_exists_with_content(index_url_suffix_md)
+
+
+def test_dirhtml_links_match_published_locations(tmp_path: Path):
+    source_dir = tmp_path / "source"
+    output_dir = tmp_path / "output"
+    guide_dir = source_dir / "guide"
+    guide_dir.mkdir(parents=True)
+
+    (source_dir / "conf.py").write_text(
+        'extensions = ["sphinx_llm.txt"]\n'
+        'project = "Link test"\n'
+        'root_doc = "index"\n'
+        "llms_txt_build_parallel = False\n"
+        'llms_txt_suffix_mode = "auto"\n'
+        "markdown_anchor_sections = True\n",
+        encoding="utf-8",
+    )
+    (source_dir / "index.rst").write_text(
+        "Index\n=====\n\n.. toctree::\n\n   guide/page\n   guide/target\n",
+        encoding="utf-8",
+    )
+    (guide_dir / "page.rst").write_text(
+        "Page\n"
+        "====\n\n"
+        "See :doc:`Target <target>`.\n\n"
+        ".. _page-details:\n\n"
+        "Details\n"
+        "-------\n\n"
+        "See :ref:`Details <page-details>`.\n",
+        encoding="utf-8",
+    )
+    (guide_dir / "target.rst").write_text(
+        "Target\n======\n",
+        encoding="utf-8",
+    )
+
+    app = Sphinx(
+        srcdir=str(source_dir),
+        confdir=str(source_dir),
+        outdir=str(output_dir),
+        doctreedir=str(tmp_path / "doctrees"),
+        buildername="dirhtml",
+        warningiserror=False,
+        freshenv=True,
+    )
+    app.build()
+
+    file_suffix_page = (output_dir / "guide/page/index.html.md").read_text(
+        encoding="utf-8"
+    )
+    url_suffix_page = (output_dir / "guide/page.md").read_text(encoding="utf-8")
+    llms_full = (output_dir / "llms-full.txt").read_text(encoding="utf-8")
+
+    assert "[Target](../target/index.html.md)" in file_suffix_page
+    assert "[Details](#page-details)" in file_suffix_page
+    assert "[Target](target.md)" in url_suffix_page
+    assert "[Details](#page-details)" in url_suffix_page
+    assert "# guide/page/index.html.md" in llms_full
+    assert "[Target](guide/target/index.html.md)" in llms_full
+    assert "[Details](guide/page/index.html.md#page-details)" in llms_full
+    assert "sphinx-llm:" not in file_suffix_page + url_suffix_page + llms_full
 
 
 @pytest.mark.parametrize(

--- a/src/sphinx_llm/txt.py
+++ b/src/sphinx_llm/txt.py
@@ -7,6 +7,7 @@ This extension hooks into the Sphinx build process to create markdown versions
 of all documents using the sphinx_markdown_builder.
 """
 
+import posixpath
 import re
 import shutil
 import subprocess
@@ -14,16 +15,25 @@ import sys
 import tempfile
 from importlib.metadata import PackageNotFoundError, metadata
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Optional, Union
+from urllib.parse import unquote
 
 import docutils.nodes
 from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
 from sphinx.util import logging
 
+from .markdown_builder import (
+    LINK_TOKEN_PREFIX,
+    SphinxLlmMarkdownBuilder,
+)
 from .version import __version__
 
 logger = logging.getLogger(__name__)
+LINK_TOKEN_PATTERN = re.compile(
+    rf"{re.escape(LINK_TOKEN_PREFIX)}(?P<docname>[^#\s)>]+)"
+    r"(?:#(?P<fragment>[^\s)>]+))?"
+)
 
 
 class MarkdownGenerator:
@@ -33,6 +43,7 @@ class MarkdownGenerator:
         self.app = app
         self.generated_markdown_files = []  # Track generated markdown files
         self._docname_by_output_file: dict[Path, str] = {}  # output file → docname
+        self._markdown_file_by_docname: dict[str, Path] = {}
         self.outdir = None
         self.md_build_dir = None
         self.md_build_process = None
@@ -140,7 +151,9 @@ class MarkdownGenerator:
                 "-m",
                 "sphinx",
                 "-b",
-                "markdown",
+                SphinxLlmMarkdownBuilder.name,
+                "-t",
+                "sphinx_llm_markdown",
                 str(self.app.srcdir),
                 str(self.md_build_dir),
             ]
@@ -271,15 +284,26 @@ class MarkdownGenerator:
         md_files = list(self.md_build_dir.rglob("*.md"))
         self.generated_markdown_files = []
         self._docname_by_output_file = {}
+        self._markdown_file_by_docname = {}
 
         for md_file in md_files:
             target_files, primary_target = self._get_target_paths(md_file)
             docname = self._get_docname_from_md_file(md_file)
+            content = md_file.read_text(encoding="utf-8")
+            self._markdown_file_by_docname[docname] = md_file
 
-            # Copy the file to all target locations
-            for target_file in target_files:
+            # Write the file with links for its published location.
+            for layout_index, target_file in enumerate(target_files):
                 target_file.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(md_file, target_file)
+                target_file.write_text(
+                    self._materialize_links(
+                        content,
+                        source_docname=docname,
+                        source_target=target_file,
+                        layout_index=layout_index,
+                    ),
+                    encoding="utf-8",
+                )
 
             # Only add the primary target to avoid duplicates in llms-full.txt
             if primary_target:
@@ -288,6 +312,53 @@ class MarkdownGenerator:
 
         logger.info(f"Generated {len(self.generated_markdown_files)} context files")
 
+    def _target_paths_for_docname(self, docname: str) -> list[Path]:
+        markdown_file = self.md_build_dir / f"{docname}.md"
+        target_files, _ = self._get_target_paths(markdown_file)
+        return target_files
+
+    def _markdown_http_base(self) -> str:
+        return (
+            self.app.config._raw_config.get("markdown_http_base")
+            or getattr(self.app.config, "markdown_http_base", "")
+        ).rstrip("/")
+
+    def _materialize_links(
+        self,
+        content: str,
+        source_docname: str,
+        source_target: Optional[Path],
+        layout_index: int,
+    ) -> str:
+        """Resolve document link tokens for one published location."""
+
+        def replace_link(match: re.Match) -> str:
+            target_docname = unquote(match.group("docname"))
+            fragment = match.group("fragment")
+            if (
+                source_target is not None
+                and target_docname == source_docname
+                and fragment
+            ):
+                return f"#{fragment}"
+
+            target_file = self._target_paths_for_docname(target_docname)[layout_index]
+            relative_target = target_file.relative_to(self.outdir).as_posix()
+            http_base = self._markdown_http_base()
+            if http_base:
+                uri = f"{http_base}/{relative_target}"
+            elif source_target is None:
+                uri = relative_target
+            else:
+                source_dir = source_target.parent.relative_to(self.outdir).as_posix()
+                uri = posixpath.relpath(relative_target, start=source_dir or ".")
+
+            if fragment:
+                uri = f"{uri}#{fragment}"
+            return uri
+
+        return LINK_TOKEN_PATTERN.sub(replace_link, content)
+
     def build_llms_full_txt(self):
         # Concatenate all markdown files into llms-full.txt
         llms_txt_path = self.outdir / "llms-full.txt"
@@ -295,14 +366,28 @@ class MarkdownGenerator:
             # Sort files to ensure index.html.md comes first
             sorted_files = sorted(
                 self.generated_markdown_files,
-                key=lambda x: (x.name not in ("index.html.md", "index.md"), x.name),
+                key=lambda path: (
+                    path.relative_to(self.outdir).as_posix()
+                    not in {"index.html.md", "index.md"},
+                    path.relative_to(self.outdir).as_posix(),
+                ),
             )
 
             for md_file in sorted_files:
-                with open(md_file, encoding="utf-8") as f:
-                    llms_txt.write(f"# {md_file.name}\n\n")
-                    llms_txt.write(f.read())
-                    llms_txt.write("\n\n")
+                docname = self._docname_by_output_file[md_file]
+                content = self._markdown_file_by_docname[docname].read_text(
+                    encoding="utf-8"
+                )
+                content = self._materialize_links(
+                    content,
+                    source_docname=docname,
+                    source_target=None,
+                    layout_index=0,
+                )
+                relative_path = md_file.relative_to(self.outdir).as_posix()
+                llms_txt.write(f"# {relative_path}\n\n")
+                llms_txt.write(content)
+                llms_txt.write("\n\n")
         logger.info(f"Concatenated full context into: {llms_txt_path}")
 
     def get_project_description(self) -> str:
@@ -356,10 +441,7 @@ class MarkdownGenerator:
             # Read markdown_http_base from raw conf.py values, so it works
             # even when sphinx_markdown_builder is not listed in extensions
             # (it is only loaded in the markdown subprocess build).
-            http_base = (
-                self.app.config._raw_config.get("markdown_http_base")
-                or getattr(self.app.config, "markdown_http_base", "")
-            ).rstrip("/")
+            http_base = self._markdown_http_base()
 
             for md_file in sorted_files:
                 # Extract title from the markdown file
@@ -495,6 +577,9 @@ class MarkdownGenerator:
 
 def setup(app: Sphinx) -> dict[str, Any]:
     """Set up the Sphinx extension."""
+    if app.tags.has("sphinx_llm_markdown"):
+        app.setup_extension("sphinx_markdown_builder")
+    app.add_builder(SphinxLlmMarkdownBuilder)
     app.add_config_value("llms_txt_enabled", True, "")
     app.add_config_value("llms_txt_description", "", "env")
     app.add_config_value("llms_txt_build_parallel", True, "env")

--- a/src/sphinx_llm/txt.py
+++ b/src/sphinx_llm/txt.py
@@ -7,16 +7,17 @@ This extension hooks into the Sphinx build process to create markdown versions
 of all documents using the sphinx_markdown_builder.
 """
 
+import json
 import posixpath
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
+from enum import Enum
 from importlib.metadata import PackageNotFoundError, metadata
 from pathlib import Path
 from typing import Any, Optional, Union
-from urllib.parse import unquote
 
 import docutils.nodes
 from sphinx.application import Sphinx
@@ -24,16 +25,24 @@ from sphinx.errors import ExtensionError
 from sphinx.util import logging
 
 from .markdown_builder import (
+    LINK_TARGETS_FILENAME,
     LINK_TOKEN_PREFIX,
+    LinkTarget,
     SphinxLlmMarkdownBuilder,
 )
 from .version import __version__
 
 logger = logging.getLogger(__name__)
-LINK_TOKEN_PATTERN = re.compile(
-    rf"{re.escape(LINK_TOKEN_PREFIX)}(?P<docname>[^#\s)>]+)"
-    r"(?:#(?P<fragment>[^\s)>]+))?"
-)
+LINK_TOKEN_PATTERN = re.compile(rf"{re.escape(LINK_TOKEN_PREFIX)}[0-9a-f]{{32}}")
+
+
+class MarkdownLayout(str, Enum):
+    """Published Markdown path layout."""
+
+    FILE_SUFFIX = "file-suffix"
+    URL_SUFFIX = "url-suffix"
+    REPLACE = "replace"
+    HTML = "html"
 
 
 class MarkdownGenerator:
@@ -44,6 +53,7 @@ class MarkdownGenerator:
         self.generated_markdown_files = []  # Track generated markdown files
         self._docname_by_output_file: dict[Path, str] = {}  # output file → docname
         self._markdown_file_by_docname: dict[str, Path] = {}
+        self._link_target_by_token: dict[str, LinkTarget] = {}
         self.outdir = None
         self.md_build_dir = None
         self.md_build_process = None
@@ -185,28 +195,41 @@ class MarkdownGenerator:
 
     def _determine_suffix_targets(
         self, file_suffix_target: Path, url_suffix_target: Path
-    ) -> tuple[list[Path], Path]:
+    ) -> tuple[dict[MarkdownLayout, Path], MarkdownLayout]:
         """Determine target file paths based on suffix mode.
 
         Returns:
-            Tuple of (list of all targets, primary target)
+            Tuple of (targets by layout, primary layout)
         """
         if self.suffix_mode == "file-suffix":
-            return [file_suffix_target], file_suffix_target
+            return (
+                {MarkdownLayout.FILE_SUFFIX: file_suffix_target},
+                MarkdownLayout.FILE_SUFFIX,
+            )
         elif self.suffix_mode == "url-suffix":
-            return [url_suffix_target], url_suffix_target
+            return (
+                {MarkdownLayout.URL_SUFFIX: url_suffix_target},
+                MarkdownLayout.URL_SUFFIX,
+            )
         elif self.suffix_mode == "auto":
-            # Use file-suffix as primary (spec-compliant)
-            return [file_suffix_target, url_suffix_target], file_suffix_target
+            return (
+                {
+                    MarkdownLayout.FILE_SUFFIX: file_suffix_target,
+                    MarkdownLayout.URL_SUFFIX: url_suffix_target,
+                },
+                MarkdownLayout.FILE_SUFFIX,
+            )
         raise ExtensionError(
             f"Unhandled suffix mode in _determine_suffix_targets: {self.suffix_mode!r}"
         )
 
-    def _get_dirhtml_root_index_targets(self, new_name: str) -> tuple[list[Path], Path]:
+    def _get_dirhtml_root_index_targets(
+        self, new_name: str
+    ) -> tuple[dict[MarkdownLayout, Path], MarkdownLayout]:
         """Get targets for root index file in dirhtml builder."""
         if self.suffix_mode == "replace":
             replace_target = self.outdir / "index.md"
-            return [replace_target], replace_target
+            return {MarkdownLayout.REPLACE: replace_target}, MarkdownLayout.REPLACE
 
         file_suffix_target = self.outdir / new_name  # index.html.md
         url_suffix_target = self.outdir / "index.md"  # index.md
@@ -214,11 +237,11 @@ class MarkdownGenerator:
 
     def _get_dirhtml_nested_index_targets(
         self, rel_path: Path, new_name: str
-    ) -> tuple[list[Path], Path]:
+    ) -> tuple[dict[MarkdownLayout, Path], MarkdownLayout]:
         """Get targets for nested index file in dirhtml builder (e.g., subdir/index.rst)."""
         if self.suffix_mode == "replace":
             replace_target = self.outdir / rel_path.parent / "index.md"
-            return [replace_target], replace_target
+            return {MarkdownLayout.REPLACE: replace_target}, MarkdownLayout.REPLACE
 
         file_suffix_target = (
             self.outdir / rel_path.parent / new_name
@@ -226,11 +249,13 @@ class MarkdownGenerator:
         url_suffix_target = self.outdir / f"{rel_path.parent}.md"  # subdir.md
         return self._determine_suffix_targets(file_suffix_target, url_suffix_target)
 
-    def _get_dirhtml_non_index_targets(self, rel_path: Path) -> tuple[list[Path], Path]:
+    def _get_dirhtml_non_index_targets(
+        self, rel_path: Path
+    ) -> tuple[dict[MarkdownLayout, Path], MarkdownLayout]:
         """Get targets for non-index file in dirhtml builder."""
         if self.suffix_mode == "replace":
             replace_target = self.outdir / rel_path.with_suffix("") / "index.md"
-            return [replace_target], replace_target
+            return {MarkdownLayout.REPLACE: replace_target}, MarkdownLayout.REPLACE
 
         file_suffix_target = self.outdir / rel_path.with_suffix("") / "index.html.md"
         url_suffix_target = self.outdir / rel_path.with_suffix(".md")
@@ -238,7 +263,7 @@ class MarkdownGenerator:
 
     def _get_html_targets(
         self, rel_path: Path, base_name: str, new_name: str
-    ) -> tuple[list[Path], Path]:
+    ) -> tuple[dict[MarkdownLayout, Path], MarkdownLayout]:
         """Get targets for html builder."""
         if self.suffix_mode == "replace":
             # Replace mode: foo.md (replace .html with .md)
@@ -247,7 +272,7 @@ class MarkdownGenerator:
                 if rel_path.parent != Path(".")
                 else self.outdir / f"{base_name}.md"
             )
-            return [replace_target], replace_target
+            return {MarkdownLayout.REPLACE: replace_target}, MarkdownLayout.REPLACE
 
         # Default behavior: foo.html.md
         target_file = (
@@ -255,13 +280,15 @@ class MarkdownGenerator:
             if rel_path.parent != Path(".")
             else self.outdir / new_name
         )
-        return [target_file], target_file
+        return {MarkdownLayout.HTML: target_file}, MarkdownLayout.HTML
 
-    def _get_target_paths(self, md_file: Path) -> tuple[list[Path], Path]:
+    def _get_target_paths(
+        self, md_file: Path
+    ) -> tuple[dict[MarkdownLayout, Path], MarkdownLayout]:
         """Determine target file locations based on builder and file type.
 
         Returns:
-            Tuple of (list of all target files, primary target for llms-full.txt)
+            Tuple of (targets by layout, primary layout)
         """
         rel_path = md_file.relative_to(self.md_build_dir)
         base_name = rel_path.stem
@@ -285,37 +312,42 @@ class MarkdownGenerator:
         self.generated_markdown_files = []
         self._docname_by_output_file = {}
         self._markdown_file_by_docname = {}
+        link_targets_path = self.md_build_dir / LINK_TARGETS_FILENAME
+        self._link_target_by_token = json.loads(
+            link_targets_path.read_text(encoding="utf-8")
+        )
 
         for md_file in md_files:
-            target_files, primary_target = self._get_target_paths(md_file)
+            target_files, primary_layout = self._get_target_paths(md_file)
+            primary_target = target_files[primary_layout]
             docname = self._get_docname_from_md_file(md_file)
             content = md_file.read_text(encoding="utf-8")
             self._markdown_file_by_docname[docname] = md_file
 
             # Write the file with links for its published location.
-            for layout_index, target_file in enumerate(target_files):
+            for layout, target_file in target_files.items():
                 target_file.parent.mkdir(parents=True, exist_ok=True)
                 target_file.write_text(
                     self._materialize_links(
                         content,
                         source_docname=docname,
                         source_target=target_file,
-                        layout_index=layout_index,
+                        target_layout=layout,
                     ),
                     encoding="utf-8",
                 )
 
             # Only add the primary target to avoid duplicates in llms-full.txt
-            if primary_target:
-                self.generated_markdown_files.append(primary_target)
-                self._docname_by_output_file[primary_target] = docname
+            self.generated_markdown_files.append(primary_target)
+            self._docname_by_output_file[primary_target] = docname
 
         logger.info(f"Generated {len(self.generated_markdown_files)} context files")
 
-    def _target_paths_for_docname(self, docname: str) -> list[Path]:
+    def _target_paths_for_docname(
+        self, docname: str
+    ) -> tuple[dict[MarkdownLayout, Path], MarkdownLayout]:
         markdown_file = self.md_build_dir / f"{docname}.md"
-        target_files, _ = self._get_target_paths(markdown_file)
-        return target_files
+        return self._get_target_paths(markdown_file)
 
     def _markdown_http_base(self) -> str:
         return (
@@ -328,13 +360,18 @@ class MarkdownGenerator:
         content: str,
         source_docname: str,
         source_target: Optional[Path],
-        layout_index: int,
+        target_layout: Optional[MarkdownLayout],
     ) -> str:
         """Resolve document link tokens for one published location."""
 
         def replace_link(match: re.Match) -> str:
-            target_docname = unquote(match.group("docname"))
-            fragment = match.group("fragment")
+            token = match.group(0)
+            link_target = self._link_target_by_token.get(token)
+            if link_target is None:
+                return token
+
+            target_docname = link_target["docname"]
+            fragment = link_target["fragment"]
             if (
                 source_target is not None
                 and target_docname == source_docname
@@ -342,7 +379,17 @@ class MarkdownGenerator:
             ):
                 return f"#{fragment}"
 
-            target_file = self._target_paths_for_docname(target_docname)[layout_index]
+            target_files, primary_layout = self._target_paths_for_docname(
+                target_docname
+            )
+            selected_layout = target_layout or primary_layout
+            try:
+                target_file = target_files[selected_layout]
+            except KeyError as exc:
+                raise ExtensionError(
+                    f"Document {target_docname!r} does not have the "
+                    f"{selected_layout.value!r} Markdown layout"
+                ) from exc
             relative_target = target_file.relative_to(self.outdir).as_posix()
             http_base = self._markdown_http_base()
             if http_base:
@@ -382,7 +429,7 @@ class MarkdownGenerator:
                     content,
                     source_docname=docname,
                     source_target=None,
-                    layout_index=0,
+                    target_layout=None,
                 )
                 relative_path = md_file.relative_to(self.outdir).as_posix()
                 llms_txt.write(f"# {relative_path}\n\n")
@@ -579,7 +626,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     """Set up the Sphinx extension."""
     if app.tags.has("sphinx_llm_markdown"):
         app.setup_extension("sphinx_markdown_builder")
-    app.add_builder(SphinxLlmMarkdownBuilder)
+        app.add_builder(SphinxLlmMarkdownBuilder)
     app.add_config_value("llms_txt_enabled", True, "")
     app.add_config_value("llms_txt_description", "", "env")
     app.add_config_value("llms_txt_build_parallel", True, "env")


### PR DESCRIPTION
Hey there 👋. We're implementing `sphinx-llm` in the NVIDIA LPU Compiler Docs and ran into a few issues with the urls that it generates. I'm not in love with this approach, however it appears to be the best of the solutions I could see.

Code and description 👇 generated by Codex.

## Problem

`sphinx-llm` builds Markdown in an intermediate directory before it selects the published file paths. Internal Sphinx links are resolved before these final paths are known.

This produces incorrect links when:

- `dirhtml` publishes both file-suffix and URL-suffix Markdown aliases.
- `llms-full.txt` contains content from nested pages but is published at the output root.

## Solution

This PR adds an internal Markdown builder that stores Sphinx document targets and anchors as temporary tokens.

When `sphinx-llm` writes the output:

- Each page Markdown file receives links relative to its published location.
- Each `dirhtml` alias receives links for its own path layout.
- Same-page references remain fragment links.
- `llms-full.txt` receives links relative to the output root.
- `markdown_http_base` remains the prefix when it is configured.
- Section headings in `llms-full.txt` include the complete published path.

External links and the `llms.txt` index are not affected. Temporary tokens do not appear in published files.

## Testing

- Added coverage for cross-page and same-page references.
- Tested both `dirhtml` Markdown path layouts.
- Tested root-relative links in `llms-full.txt`.
- Verified that no temporary tokens remain in generated files.
- Ran `uv run --extra gen pytest -q`.