### PR TITLE
Avoid orphaned markdown sub-builds on build failure

### DIFF
--- a/src/sphinx_llm/tests/test_txt.py
+++ b/src/sphinx_llm/tests/test_txt.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 
 import re
 import shutil
+import subprocess
 import tempfile
 from collections.abc import Generator
 from html.parser import HTMLParser
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 import docutils.nodes
 import pytest
@@ -184,6 +185,48 @@ def test_combine_builds_with_exception(sphinx_build):
     app, _, _ = sphinx_build
     generator = MarkdownGenerator(app)
     generator.combine_builds(app, Exception("fail"))
+
+
+def test_combine_builds_terminates_orphan_subprocess_on_exception(sphinx_build):
+    """Test that a failed primary build terminates a running markdown sub-build."""
+    app, _, _ = sphinx_build
+    generator = MarkdownGenerator(app)
+    process = MagicMock()
+    process.poll.return_value = None
+    generator.md_build_process = process
+
+    generator.combine_builds(app, Exception("primary build failed"))
+
+    process.terminate.assert_called_once_with()
+    process.wait.assert_called_once_with(timeout=10)
+    process.kill.assert_not_called()
+
+
+def test_combine_builds_kills_unresponsive_subprocess_on_exception(sphinx_build):
+    """Test that an unresponsive markdown sub-build is killed and reaped."""
+    app, _, _ = sphinx_build
+    generator = MarkdownGenerator(app)
+    process = MagicMock()
+    process.poll.return_value = None
+    process.wait.side_effect = [subprocess.TimeoutExpired("sphinx", 10), None]
+    generator.md_build_process = process
+
+    generator.combine_builds(app, Exception("primary build failed"))
+
+    process.terminate.assert_called_once_with()
+    process.kill.assert_called_once_with()
+    assert process.wait.call_args_list == [call(timeout=10), call()]
+
+
+def test_build_markdown_files_skips_failed_primary_build(sphinx_build):
+    """Test that a failed primary build does not start a sequential sub-build."""
+    app, _, _ = sphinx_build
+    generator = MarkdownGenerator(app)
+
+    with patch("sphinx_llm.txt.subprocess.Popen") as popen:
+        generator.build_markdown_files(app, Exception("primary build failed"))
+
+    popen.assert_not_called()
 
 
 def test_rst_files_have_corresponding_output_files(sphinx_build):

--- a/src/sphinx_llm/txt.py
+++ b/src/sphinx_llm/txt.py
@@ -137,6 +137,19 @@ class MarkdownGenerator:
         """Combine the markdown files into llms-full.txt and llms.txt and merge the build outputs together."""
         if exception:
             logger.warning("Skipping build combination due to build error")
+            # Don't leave a markdown build subprocess behind (parallel mode).
+            if self.md_build_process and self.md_build_process.poll() is None:
+                logger.info("Terminating markdown build subprocess...")
+                self.md_build_process.terminate()
+                try:
+                    self.md_build_process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    logger.warning(
+                        "Markdown build subprocess did not exit after terminate(); "
+                        "killing it"
+                    )
+                    self.md_build_process.kill()
+                    self.md_build_process.wait()
             return
 
         if not self.md_build_process:
@@ -176,7 +189,14 @@ class MarkdownGenerator:
             if self.md_build_dir.exists():
                 shutil.rmtree(self.md_build_dir)
 
-    def build_markdown_files(self, *_):
+    def build_markdown_files(
+        self, app: Sphinx | None = None, exception: Exception | None = None
+    ):
+        """Start the markdown sub-build unless the primary build failed."""
+        if exception is not None:
+            logger.info("Skipping markdown build because the primary build failed")
+            return
+
         # Create temporary markdown build directory
         self.md_build_dir.mkdir(exist_ok=True)
         self.md_build_logfile = tempfile.NamedTemporaryFile(


### PR DESCRIPTION
Supersedes #104.

When the primary Sphinx build fails:

- sequential markdown generation is skipped rather than starting a sub-build;
- a running parallel markdown sub-build is terminated, given 10 seconds to exit, then killed and reaped if needed.

This also replaces the event callback's variadic positional-argument check with explicit app and exception parameters.

Tests:

- txt test suite: 114 passed
- pre-commit hooks pass

The complete suite continues to have existing failures in summary-related tests outside this change.