### PR TITLE
Pin sphinx-markdown-builder newline fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,10 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["sphinx-markdown-builder>=0.6.8", "sphinx>=5"]
+dependencies = [
+    "sphinx-markdown-builder @ git+https://github.com/liran-funaro/sphinx-markdown-builder.git@9fa1a55013d251bde3bafe5dbeb190bdcef41291",
+    "sphinx>=5",
+]
 
 [project.optional-dependencies]
 gen = ["openai>=1.0.0"]
@@ -40,6 +43,9 @@ source = "vcs"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/sphinx_llm/_version.py"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.envs.types]
 extra-dependencies = ["mypy>=1.0.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -1407,7 +1407,7 @@ dev = [
 requires-dist = [
     { name = "openai", marker = "extra == 'gen'", specifier = ">=1.0.0" },
     { name = "sphinx", specifier = ">=5" },
-    { name = "sphinx-markdown-builder", specifier = ">=0.6.8" },
+    { name = "sphinx-markdown-builder", git = "https://github.com/liran-funaro/sphinx-markdown-builder.git?rev=9fa1a55013d251bde3bafe5dbeb190bdcef41291" },
 ]
 provides-extras = ["gen"]
 
@@ -1421,7 +1421,7 @@ dev = [
 [[package]]
 name = "sphinx-markdown-builder"
 version = "0.6.10"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/liran-funaro/sphinx-markdown-builder.git?rev=9fa1a55013d251bde3bafe5dbeb190bdcef41291#9fa1a55013d251bde3bafe5dbeb190bdcef41291" }
 dependencies = [
     { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1432,11 +1432,6 @@ dependencies = [
     { name = "tabulate", version = "0.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "tabulate", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/58/0b7b9a7d071140b3705885d51932e8b62f520388c2772e4952189971727b/sphinx_markdown_builder-0.6.10.tar.gz", hash = "sha256:cd5acf88d52ea0146a712fd557404f10326dff3428a78ba928e59b1727fd4a86", size = 22688, upload-time = "2026-03-11T10:56:57.639Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/8f/9fecf3d081d5cd49eff83a17b9fef50ed741e6223ab3bb906de4ab0068f9/sphinx_markdown_builder-0.6.10-py3-none-any.whl", hash = "sha256:16d86738b9ac69fcbc86e373c31c6402c30af1fa8d98d0f62cc5f38bfe5fc26e", size = 16700, upload-time = "2026-03-11T10:56:56.135Z" },
-]
-
 [[package]]
 name = "sphinxcontrib-applehelp"
 version = "2.0.0"


### PR DESCRIPTION
Pins `sphinx-markdown-builder` to the latest version which includes a fix for multiline markdown.

<img src="https://static.klipy.com/ii/4e7bea9f7a3371424e6c16ebc93252fe/6c/3a/DhEOtehyRNQa.gif"/>