### PR TITLE
Allow manually running Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,7 @@ exclude-labels:
   - "good first issue"
   - "good ai issue"
   - "help wanted"
+  - "hygiene"
 
 categories:
   - title: "🚨 Breaking changes"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,6 +1,7 @@
 name: Update release draft
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Add a workflow_dispatch trigger so Release Drafter can be run from the GitHub Actions UI.
- Exclude pull requests labelled hygiene from generated release notes.

## Validation
- Prettier passed for both edited YAML files.
- git diff --check passed.

## Test suite
The default test environment lacks the optional openai package required by summary-generation tests. Details are recorded locally in /tmp/sphinx-llm-test-suite-problem.txt.