### PR TITLE
Forward the primary build's tags to the markdown sub-build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Forwarded the primary build's tags (`sphinx-build -t` option, including the
+  dynamic builder-derived tags such as `html`) to the markdown sub-build so
+  that conditional content (e.g. `.. only::` directives) renders the same in
+  the markdown output as in the HTML build.
+
 ### Changed
 
 - Reworked the `docref` directive around Sphinx's environment lifecycle,

--- a/src/sphinx_llm/tests/test_txt.py
+++ b/src/sphinx_llm/tests/test_txt.py
@@ -1115,3 +1115,49 @@ def test_confdir_outside_srcdir():
         assert_file_exists_with_content(build_dir / "llms.txt")
         assert_file_exists_with_content(build_dir / "llms-full.txt")
         assert_file_exists_with_content(build_dir / "index.html.md")
+
+
+def test_tags_forwarded_to_markdown_build():
+    """Tags of the primary build (sphinx-build -t option) must be forwarded
+    to the markdown sub-build so that conditional content (".. only::")
+    renders the same in both outputs."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        srcdir = temp_path / "source"
+        build_dir = temp_path / "build"
+        doctree_dir = temp_path / "doctrees"
+
+        srcdir.mkdir()
+        (srcdir / "conf.py").write_text('extensions = ["sphinx_llm.txt"]\n')
+        (srcdir / "index.rst").write_text(
+            "Test\n"
+            "====\n"
+            "\n"
+            "Always visible.\n"
+            "\n"
+            ".. only:: custom_tag\n"
+            "\n"
+            "   Tagged content marker.\n"
+        )
+
+        app = Sphinx(
+            srcdir=str(srcdir),
+            confdir=str(srcdir),
+            outdir=str(build_dir),
+            doctreedir=str(doctree_dir),
+            buildername="html",
+            warningiserror=False,
+            freshenv=True,
+            tags=["custom_tag"],
+            confoverrides={"llms_txt_build_parallel": True},
+        )
+        app.build()
+
+        index_md = build_dir / "index.html.md"
+        assert_file_exists_with_content(index_md)
+        content = index_md.read_text()
+        assert "Always visible." in content
+        assert "Tagged content marker." in content, (
+            "Content behind a tag of the primary build is missing from the "
+            "markdown output; tags were not forwarded to the sub-build"
+        )

--- a/src/sphinx_llm/txt.py
+++ b/src/sphinx_llm/txt.py
@@ -226,6 +226,15 @@ class MarkdownGenerator:
                 str(self.md_build_dir),
             ]
 
+            # Propagate the tags of the primary build so that conditional
+            # content (e.g. ".. only::" directives) renders the same in the
+            # markdown output. This intentionally includes the dynamic tags
+            # derived from the primary builder (e.g. "html", "format_html"):
+            # the markdown output this way stays faithful to the HTML pages it
+            # complements.
+            for tag in self.app.tags:
+                sphinx_build_cmd += ["-t", tag]
+
             # When building sequentially we can reuse the doctree directory from the primary build
             # but in parallel builds these may clobber each other so we need to use a separate one
             if not self.parallel:


### PR DESCRIPTION
Conditional content (".. only::" directives, tags-based configuration) used to render differently in the markdown output than in the HTML build, since the sub-build was spawned without any of the tags the primary build was invoked with (sphinx-build -t option).

The dynamic tags derived from the primary builder ("html", "format_html", "builder_html") are forwarded too, so that ".. only:: html" content is included in the markdown rendition of the pages, keeping it faithful to the HTML output it complements.