### PR TITLE
feat: make unsupported node types markdown-friendly before writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Convert node types `sphinx-markdown-builder` does not support (tip and
+  caution admonitions, generic admonitions, sidebars, figure captions and
+  legends, abbreviations) into markdown-friendly equivalents before writing,
+  so their content is no longer dropped from the markdown output.
+
 ### Changed
 
 - Reworked the `docref` directive around Sphinx's environment lifecycle,

--- a/src/sphinx_llm/markdown_builder.py
+++ b/src/sphinx_llm/markdown_builder.py
@@ -4,10 +4,11 @@
 
 import json
 from pathlib import Path
-from typing import Optional, TypedDict
+from typing import Any, Optional, TypedDict
 from uuid import uuid4
 
 from docutils import nodes
+from sphinx.transforms.post_transforms import SphinxPostTransform
 from sphinx_markdown_builder.builder import MarkdownBuilder
 from sphinx_markdown_builder.translator import MarkdownTranslator
 
@@ -77,3 +78,58 @@ class SphinxLlmMarkdownBuilder(MarkdownBuilder):
             json.dumps(self._link_target_by_token, sort_keys=True),
             encoding="utf-8",
         )
+
+
+class MarkdownFriendlyNodesTransform(SphinxPostTransform):
+    """Make documents more markdown-friendly before they get written.
+
+    ``sphinx-markdown-builder`` drops the nodes it does not support (they only
+    produce an "unknown node type" warning), which would result in content
+    missing from the markdown output. Convert the affected node types into
+    supported equivalents.
+    """
+
+    default_priority = 400
+    formats = ("markdown",)
+
+    def run(self, **kwargs: Any) -> None:
+        # Generic admonitions and sidebars become a bold title followed by
+        # their content.
+        for node in [
+            *self.document.findall(nodes.admonition),
+            *self.document.findall(nodes.sidebar),
+        ]:
+            children = []
+            for child in node.children:
+                if isinstance(child, nodes.title):
+                    para = nodes.paragraph()
+                    para += nodes.strong(text=child.astext())
+                    children.append(para)
+                elif isinstance(child, nodes.raw):
+                    continue
+                else:
+                    children.append(child)
+            node.replace_self(children)
+
+        # Map unsupported admonition flavors to supported ones with a similar
+        # meaning.
+        for node in list(self.document.findall(nodes.tip)):
+            node.replace_self(nodes.hint("", *node.children))
+
+        for node in list(self.document.findall(nodes.caution)):
+            node.replace_self(nodes.attention("", *node.children))
+
+        # Figure captions and legends are dropped by the markdown builder;
+        # turn them into regular content.
+        for node in list(self.document.findall(nodes.caption)):
+            para = nodes.paragraph()
+            para += nodes.emphasis(text=node.astext())
+            node.replace_self(para)
+
+        for node in list(self.document.findall(nodes.legend)):
+            node.replace_self(node.children)
+
+        # Abbreviations are inline elements: dropping them would remove words
+        # from the middle of sentences. Keep their text.
+        for node in list(self.document.findall(nodes.abbreviation)):
+            node.replace_self(node.children)

--- a/src/sphinx_llm/tests/test_markdown_friendly_nodes.py
+++ b/src/sphinx_llm/tests/test_markdown_friendly_nodes.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the MarkdownFriendlyNodesTransform post-transform.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+from sphinx.application import Sphinx
+
+# A valid 1x1 transparent PNG, for exercising figure captions and legends.
+PIXEL_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+def test_unsupported_nodes_are_converted_to_markdown(tmp_path: Path):
+    """Nodes sphinx-markdown-builder would drop are kept in the markdown output."""
+    source_dir = tmp_path / "source"
+    output_dir = tmp_path / "output"
+    source_dir.mkdir()
+
+    (source_dir / "conf.py").write_text(
+        'extensions = ["sphinx_llm.txt"]\n'
+        'project = "Markdown-friendly nodes test"\n'
+        'root_doc = "index"\n'
+        "llms_txt_build_parallel = False\n",
+        encoding="utf-8",
+    )
+    (source_dir / "pixel.png").write_bytes(PIXEL_PNG)
+    (source_dir / "index.rst").write_text(
+        "Index\n"
+        "=====\n\n"
+        ".. tip::\n\n"
+        "   Tip admonition body.\n\n"
+        ".. caution::\n\n"
+        "   Caution admonition body.\n\n"
+        ".. admonition:: Custom Admonition Title\n\n"
+        "   Generic admonition body.\n\n"
+        ".. sidebar:: Sidebar Title\n\n"
+        "   Sidebar body.\n\n"
+        "A sentence with an :abbr:`LLM (Large Language Model)` "
+        "in the middle.\n\n"
+        ".. figure:: pixel.png\n\n"
+        "   Figure caption text.\n\n"
+        "   Figure legend paragraph.\n",
+        encoding="utf-8",
+    )
+
+    app = Sphinx(
+        srcdir=str(source_dir),
+        confdir=str(source_dir),
+        outdir=str(output_dir),
+        doctreedir=str(tmp_path / "doctrees"),
+        buildername="html",
+        warningiserror=False,
+    )
+    app.build()
+
+    markdown = (output_dir / "index.html.md").read_text(encoding="utf-8")
+
+    # Tip and caution admonitions are mapped to supported flavors.
+    assert "Tip admonition body." in markdown
+    assert "Caution admonition body." in markdown
+
+    # Generic admonitions and sidebars become a bold title and their content.
+    assert "**Custom Admonition Title**" in markdown
+    assert "Generic admonition body." in markdown
+    assert "**Sidebar Title**" in markdown
+    assert "Sidebar body." in markdown
+
+    # Abbreviations keep their text instead of losing words mid-sentence.
+    assert "A sentence with an LLM in the middle." in markdown
+
+    # Figure captions and legends become regular (emphasized) content.
+    assert "*Figure caption text.*" in markdown
+    assert "Figure legend paragraph." in markdown

--- a/src/sphinx_llm/txt.py
+++ b/src/sphinx_llm/txt.py
@@ -35,6 +35,7 @@ from .markdown_builder import (
     LINK_TARGETS_FILENAME,
     LINK_TOKEN_PREFIX,
     LinkTarget,
+    MarkdownFriendlyNodesTransform,
     SphinxLlmMarkdownBuilder,
 )
 from .summary import DEFAULT_API_KEY_ENV
@@ -1096,6 +1097,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     if app.tags.has("sphinx_llm_markdown"):
         app.setup_extension("sphinx_markdown_builder")
         app.add_builder(SphinxLlmMarkdownBuilder)
+    app.add_post_transform(MarkdownFriendlyNodesTransform)
     app.add_config_value("llms_txt_enabled", True, "")
     app.add_config_value("llms_txt_description", "", "env")
     app.add_config_value("llms_txt_build_parallel", True, "env")


### PR DESCRIPTION
sphinx-markdown-builder drops the node types it does not support (they only produce an "unknown node type" warning), silently losing content from the markdown renditions and the llms.txt outputs. Convert the affected node types into supported equivalents in a post-transform that runs before documents get written:

- tip and caution admonitions are mapped to hint and attention, which render as markdown boxes with a similar meaning
- generic admonitions and sidebars become a bold title followed by their content
- figure captions and legends are turned into regular (emphasized) content
- abbreviations keep their text, so words are no longer removed from the middle of sentences